### PR TITLE
Update README link to point to the correct page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 > translate integration plugin for rspress
 
-[Documentation](https://rspress.dev/plugin/official-plugins/translate)
+[Documentation](https://rspress.dev/plugin/community-plugins/translate)


### PR DESCRIPTION
since the plugin was moved to the community section instead of the official section, the readme link is now broken. Updated to point to the correct page.